### PR TITLE
exit on os.Interrupt

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -20,6 +22,13 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		os.Exit(0)
+	}()
 
 	go func() {
 		exporter.run()


### PR DESCRIPTION
Add simple os.Interrupt catch that does a clean exit.  This allows rsyslog to signal the exporter to shut down when it shuts down.  We don't need to be fancy.